### PR TITLE
Add Astro React webapp scaffolding

### DIFF
--- a/DIFF_20250627_160411.md
+++ b/DIFF_20250627_160411.md
@@ -1,0 +1,13 @@
+# DIFF Log 2025-06-27 16:04 UTC
+## Added Files
+- webapp/astro-app/README.md
+- webapp/astro-app/astro.config.mjs
+- webapp/astro-app/package.json
+- webapp/astro-app/postcss.config.cjs
+- webapp/astro-app/src/components/App.tsx
+- webapp/astro-app/src/pages/index.astro
+- webapp/astro-app/src/styles/global.css
+- webapp/astro-app/tailwind.config.cjs
+- webapp/astro-app/tsconfig.json
+
+Scaffolded an Astro + React + Tailwind webapp providing placeholder tabs for spreadsheet, SQL viewer, query editor, scripts, and settings.

--- a/RECOMMENDATIONS_20250627_160411.md
+++ b/RECOMMENDATIONS_20250627_160411.md
@@ -1,0 +1,5 @@
+# Recommendations 2025-06-27 16:04 UTC
+- Integrate OAuth middleware from the `cloudcurio-oauth` project for secure access.
+- Implement real spreadsheet and SQL viewer components (e.g., using `react-data-grid` and a lightweight SQL client).
+- Add API routes within Astro to proxy requests to backend LangChain services.
+- Provide Docker or Tunnel configuration to expose the webapp on `lang.cloudcurio.cc` via Cloudflare Tunnels and ZeroTier.

--- a/webapp/astro-app/README.md
+++ b/webapp/astro-app/README.md
@@ -1,0 +1,20 @@
+# Astro Data Webapp
+
+This example web application demonstrates how to combine **Astro**, **React**, and **Tailwind CSS** to build a professional dashboard for LangChain data analysis.
+
+It contains placeholder components for:
+
+- A spreadsheet-like interface
+- SQL database viewer
+- SQL query writer
+- Script toolkit for scraping bulk data
+- User profile and database configuration settings
+
+The app is intended to run behind an OAuth gateway and can be served from a subdomain such as `lang.cloudcurio.cc`.
+
+To develop locally:
+
+```bash
+npm install
+npm run dev
+```

--- a/webapp/astro-app/astro.config.mjs
+++ b/webapp/astro-app/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+import tailwind from '@astrojs/tailwind';
+
+export default defineConfig({
+  integrations: [react(), tailwind()],
+});

--- a/webapp/astro-app/package.json
+++ b/webapp/astro-app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "astro-data-webapp",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.7.0",
+    "@astrojs/react": "^3.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@astrojs/tailwind": "^3.1.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31"
+  }
+}

--- a/webapp/astro-app/postcss.config.cjs
+++ b/webapp/astro-app/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/webapp/astro-app/src/components/App.tsx
+++ b/webapp/astro-app/src/components/App.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+const TABS = ['Spreadsheet', 'DB Viewer', 'Query Writer', 'Scripts', 'Settings'];
+
+export default function App() {
+  const [tab, setTab] = useState('Spreadsheet');
+
+  return (
+    <div className="min-h-screen bg-gray-100 p-4">
+      <h1 className="text-2xl font-bold mb-4">Data Analysis Dashboard</h1>
+      <div className="flex space-x-4 mb-4">
+        {TABS.map((name) => (
+          <button
+            key={name}
+            onClick={() => setTab(name)}
+            className={`px-3 py-1 border-b-2 ${tab === name ? 'border-blue-500' : 'border-transparent'}`}
+          >
+            {name}
+          </button>
+        ))}
+      </div>
+      <div className="bg-white rounded shadow p-4">
+        {tab === 'Spreadsheet' && <p>Spreadsheet component goes here.</p>}
+        {tab === 'DB Viewer' && <p>SQL database viewer goes here.</p>}
+        {tab === 'Query Writer' && <p>Query writing tools go here.</p>}
+        {tab === 'Scripts' && <p>Script toolkit for API scraping goes here.</p>}
+        {tab === 'Settings' && <p>User profile and DB config settings.</p>}
+      </div>
+    </div>
+  );
+}

--- a/webapp/astro-app/src/pages/index.astro
+++ b/webapp/astro-app/src/pages/index.astro
@@ -1,0 +1,15 @@
+---
+import App from '../components/App.tsx';
+import "../styles/global.css";
+---
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LangChain Data Dashboard</title>
+  </head>
+  <body class="font-sans">
+    <App client:load />
+  </body>
+</html>

--- a/webapp/astro-app/src/styles/global.css
+++ b/webapp/astro-app/src/styles/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/webapp/astro-app/tailwind.config.cjs
+++ b/webapp/astro-app/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{astro,html,js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/webapp/astro-app/tsconfig.json
+++ b/webapp/astro-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "jsxImportSource": "react",
+    "baseUrl": ".",
+    "types": ["astro/client"],
+    "allowJs": true
+  }
+}


### PR DESCRIPTION
## Summary
- add Astro+React webapp skeleton with TailwindCSS
- create placeholder tabs for spreadsheet, SQL viewer, query writer, scripts and settings
- include documentation in README
- log diffs and recommendations

## Testing
- `make format`
- `pytest tests/test_rag_webapp.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebfdd1e74832aa32b88215e6adf22

## Summary by Sourcery

Create a new Astro-based React webapp scaffold with TailwindCSS, placeholder tabs for core features, and accompanying documentation and logs

New Features:
- Scaffold initial Astro+React webapp with TailwindCSS and placeholder UI components

Enhancements:
- Add tab navigation placeholders for spreadsheet, DB viewer, query writer, scripts, and settings

Build:
- Configure Astro with React and Tailwind integrations and setup relevant config files

Documentation:
- Add README with setup instructions and component descriptions
- Add DIFF and RECOMMENDATIONS markdown logs outlining added files and future improvements